### PR TITLE
2.1.0 router port

### DIFF
--- a/dapeng-core/src/main/java/com/github/dapeng/core/helper/IPUtils.java
+++ b/dapeng-core/src/main/java/com/github/dapeng/core/helper/IPUtils.java
@@ -86,18 +86,6 @@ public class IPUtils {
         return (ip1 & maskIp) == (ip2 & maskIp);
     }
 
-    /**
-     * 在ip匹配成功的基础上，对 remote server 端口进行匹配过滤
-     *
-     * @param ip1
-     * @param ip2
-     * @param mask 子网掩码
-     * @return
-     */
-    public static boolean matchIpInstanceWithPort(int ip1, int ip2, int mask) {
-        int maskIp = (0xFFFFFFFF << (32 - mask));
-        return (ip1 & maskIp) == (ip2 & maskIp);
-    }
 
     /**
      * transfer ip from int to human-readable format,

--- a/dapeng-core/src/main/java/com/github/dapeng/core/helper/IPUtils.java
+++ b/dapeng-core/src/main/java/com/github/dapeng/core/helper/IPUtils.java
@@ -78,7 +78,7 @@ public class IPUtils {
      *
      * @param ip1
      * @param ip2
-     * @param mask     子网掩码
+     * @param mask 子网掩码
      * @return
      */
     public static boolean matchIpWithMask(int ip1, int ip2, int mask) {
@@ -87,9 +87,23 @@ public class IPUtils {
     }
 
     /**
+     * 在ip匹配成功的基础上，对 remote server 端口进行匹配过滤
+     *
+     * @param ip1
+     * @param ip2
+     * @param mask 子网掩码
+     * @return
+     */
+    public static boolean matchIpInstanceWithPort(int ip1, int ip2, int mask) {
+        int maskIp = (0xFFFFFFFF << (32 - mask));
+        return (ip1 & maskIp) == (ip2 & maskIp);
+    }
+
+    /**
      * transfer ip from int to human-readable format,
      * for example:
      * -1062729086 ==> 192.168.10.130
+     *
      * @param ip
      * @return
      */

--- a/dapeng-router/src/main/java/com/github/dapeng/router/RoutesExecutor.java
+++ b/dapeng-router/src/main/java/com/github/dapeng/router/RoutesExecutor.java
@@ -44,9 +44,6 @@ public class RoutesExecutor {
     public static List<RuntimeInstance> executeRoutes(InvocationContextImpl ctx, List<Route> routes, List<RuntimeInstance> instances) {
         StringBuilder logAppend = new StringBuilder();
         instances.forEach(ins -> logAppend.append(ins.toString()).append(" "));
-        logger.debug(RoutesExecutor.class.getSimpleName() + "::executeRoutes$开始过滤：过滤前 size  {}，实例: {}", instances.size(), logAppend.toString());
-        boolean isMatched = false;
-        instances.forEach(ins -> logAppend.append(ins.toString()).append(" "));
         logger.debug(RoutesExecutor.class.getSimpleName() + "::executeRoutes开始过滤：过滤前 size  {}，实例: {}", instances.size(), logAppend.toString());
         boolean isMatched;
         for (Route route : routes) {
@@ -58,8 +55,9 @@ public class RoutesExecutor {
 
                     if (logger.isDebugEnabled()) {
                         StringBuilder append = new StringBuilder();
-                        instances.forEach(ins -> append.append(ins.toString()).append(" "));
-                        logger.debug(RoutesExecutor.class.getSimpleName() + "::executeRoutes过滤结果 size: {}, 实例: {}",
+                        instances.forEach(ins -> append.append(ins.toString() + " "));
+                        logger.debug(RoutesExecutor.class.getSimpleName() + "::route left " + route.getLeft().toString() +
+                                        "::executeRoutes过滤结果 size: {}, 实例: {}",
                                 instances.size(), append.toString());
                     }
                     break;

--- a/dapeng-router/src/main/java/com/github/dapeng/router/RoutesExecutor.java
+++ b/dapeng-router/src/main/java/com/github/dapeng/router/RoutesExecutor.java
@@ -6,6 +6,7 @@ import com.github.dapeng.core.RuntimeInstance;
 import com.github.dapeng.core.helper.IPUtils;
 import com.github.dapeng.router.condition.*;
 import com.github.dapeng.router.pattern.*;
+import com.github.dapeng.router.token.IpToken;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,7 +43,7 @@ public class RoutesExecutor {
      */
     public static List<RuntimeInstance> executeRoutes(InvocationContextImpl ctx, List<Route> routes, List<RuntimeInstance> instances) {
         StringBuilder logAppend = new StringBuilder();
-        instances.forEach(ins -> logAppend.append(ins.toString() + " "));
+        instances.forEach(ins -> logAppend.append(ins.toString()).append(" "));
         logger.debug(RoutesExecutor.class.getSimpleName() + "::executeRoutes$开始过滤：过滤前 size  {}，实例: {}", instances.size(), logAppend.toString());
         boolean isMatched = false;
         for (Route route : routes) {
@@ -54,7 +55,7 @@ public class RoutesExecutor {
 
                     if (logger.isDebugEnabled()) {
                         StringBuilder append = new StringBuilder();
-                        instances.forEach(ins -> append.append(ins.toString() + " "));
+                        instances.forEach(ins -> append.append(ins.toString()).append(" "));
                         logger.debug(RoutesExecutor.class.getSimpleName() + "::executeRoutes过滤结果 size: {}, 实例: {}",
                                 instances.size(), append.toString());
                     }
@@ -82,7 +83,7 @@ public class RoutesExecutor {
             return true;
         }
         Matchers matcherCondition = (Matchers) left;
-        List<Matcher> matchers = matcherCondition.macthers;
+        List<Matcher> matchers = matcherCondition.matchers;
         /**
          * left = matcher(;matcher)*
          * matcher = id match patterns
@@ -130,9 +131,8 @@ public class RoutesExecutor {
                 ips.add(ip);
             }
         });
-        List<RuntimeInstance> filters = instances.stream().filter(inst ->
-                ipMatch(ips, notIps, IPUtils.transferIp(inst.ip))).collect(Collectors.toList());
-        return filters;
+        return instances.stream().filter(inst ->
+                ipMatch(ips, notIps, IPUtils.transferIp(inst.ip), inst.port)).collect(Collectors.toList());
     }
 
     /**
@@ -140,54 +140,69 @@ public class RoutesExecutor {
      *
      * @param ips    路由规则定义路由到的 ip 列表
      * @param notIps 路由规则定义 非 路由到的 ip 列表
-     * @param value  传入的 instance ip
-     * @return
+     * @param value  传入的 remote server instance ip
+     * @param port   传入的 remote server instance port
+     * @return {@code true} or {@code false }
      */
-    private static boolean ipMatch(Set<ThenIp> ips, Set<ThenIp> notIps, int value) {
+    private static boolean ipMatch(Set<ThenIp> ips, Set<ThenIp> notIps, int value, int port) {
         if (!ips.isEmpty() && notIps.isEmpty()) {
-            for (ThenIp ip : ips) {
-                boolean result = matchIpWithMask(ip.ip, value, ip.mask);
-                if (result) {
-                    return true;
-                }
-            }
-            return false;
+            return ipMatchPositive(ips, value, port);
         }
 
         /**
-         * right 同时存在 撇配 ip 和 非 匹配 ip 模式时。
+         * right 同时存在 {@code 匹配 ip} 和 {@code 非匹配 ip} 模式时。
          * 1.先对非匹配ip模式进行 match判断，如果 instances ip 匹配上， 则 返回 false ，因为这里是 非匹配模式
          * 2。 如果非匹配模式里的ip 没有和 instance ip 匹配上，则进入下一步
          * 3,  instance ip 和 正常 匹配模式进行匹配 ，如果 匹配上 返回 true ,如果 都没匹配上，则返回 false
          */
-        if (!ips.isEmpty() && !notIps.isEmpty()) {
-            for (ThenIp notMatch : notIps) {
-                boolean result = matchIpWithMask(notMatch.ip, value, notMatch.mask);
-                if (result) {
-                    return false;
-                }
-            }
+        if (!ips.isEmpty()) {
+            // if true, go next
+            boolean notMatch = ipMatchNegative(notIps, value, port);
 
-            for (ThenIp match : ips) {
-                boolean matchResult = matchIpWithMask(match.ip, value, match.mask);
-                if (matchResult) {
-                    return true;
-                }
+            if (!notMatch) {
+                return false;
             }
-            return false;
+            return ipMatchPositive(ips, value, port);
         }
-
-        if (!notIps.isEmpty() && ips.isEmpty()) {
-            for (ThenIp notMatch : notIps) {
-                boolean result = matchIpWithMask(notMatch.ip, value, notMatch.mask);
-                if (result) {
-                    return false;
-                }
-            }
-            return true;
+        //只存在 notIp 模式
+        if (!notIps.isEmpty()) {
+            return ipMatchNegative(notIps, value, port);
         }
         return false;
     }
+
+    /**
+     * 正匹配模式
+     */
+    private static boolean ipMatchPositive(Set<ThenIp> ips, int value, int port) {
+        for (ThenIp ip : ips) {
+            boolean result = matchIpWithMask(ip.ip, value, ip.mask);
+            if (result) {
+                //如果路由表达式没有配置port，这里就是默认的端口，不参与route，直接返回 true
+                //如果不是默认端口，则说明需要根据端口进行路由，需要二者相等才能成功路由。
+                if (ip.port == IpToken.DEFAULT_PORT || ip.port == port) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * 反匹配模式
+     */
+    private static boolean ipMatchNegative(Set<ThenIp> notIps, int value, int port) {
+        for (ThenIp notMatch : notIps) {
+            boolean result = matchIpWithMask(notMatch.ip, value, notMatch.mask);
+            if (result) {
+                if (notMatch.port == IpToken.DEFAULT_PORT || notMatch.port == port) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
 
     /**
      * match on Matcher.id
@@ -219,8 +234,11 @@ public class RoutesExecutor {
             case "callerIp":
                 ctxValue = ctx.callerIp().map(String::valueOf).orElse("");
                 break;
+            case "calleeIp":
+                ctxValue = ctx.calleeIp().map(String::valueOf).orElse("");
+                break;
             case "userIp":
-                 ctxValue = ctx.userIp().map(String::valueOf).orElse("");
+                ctxValue = ctx.userIp().map(String::valueOf).orElse("");
                 break;
             default:
                 if (id.startsWith(COOKIE_PREFIX)) {

--- a/dapeng-router/src/main/java/com/github/dapeng/router/RoutesLexer.java
+++ b/dapeng-router/src/main/java/com/github/dapeng/router/RoutesLexer.java
@@ -6,6 +6,7 @@ import com.github.dapeng.router.token.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Arrays;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -37,7 +38,6 @@ public class RoutesLexer {
     static SimpleToken Token_EOF = new SimpleToken(EOF);
     static SimpleToken Token_SEMI_COLON = new SimpleToken(Token.SEMI_COLON);
     static SimpleToken Token_COMMA = new SimpleToken(Token.COMMA);
-
 
 
     /**
@@ -165,7 +165,7 @@ public class RoutesLexer {
         char ch = nextChar();
         StringBuilder sb = new StringBuilder(16);
         do {
-            throwExWithCondition(ch == EOI || ch == EOF,
+            throwExWithCondition(ch == EOI,
                     "[RegexEx]", "parse IP_REGEX failed,check the IP_REGEX express:" + sb.toString());
             sb.append(ch);
         } while ((ch = nextChar()) != quotation);
@@ -217,7 +217,7 @@ public class RoutesLexer {
         char quotation = currentChar();
         char ch = nextChar();
         do {
-            throwExWithCondition(ch == EOI || ch == EOF,
+            throwExWithCondition(ch == EOI,
                     "[StringEx]", "parse string failed,check the string express:" + sb.toString());
             sb.append(ch);
         } while ((ch = nextChar()) != quotation);
@@ -263,7 +263,7 @@ public class RoutesLexer {
         StringBuilder sb = new StringBuilder(16);
 
         do {
-            throwExWithCondition(ch == EOI || ch == EOF,
+            throwExWithCondition(ch == EOI,
                     "[ModeEx]", "parse mode failed,check the mode express:" + sb.toString());
             sb.append(ch);
         } while ((ch = nextChar()) != quotation);
@@ -295,7 +295,7 @@ public class RoutesLexer {
 
         StringBuilder sb = new StringBuilder(16);
         do {
-            throwExWithCondition(ch == EOI || ch == EOF,
+            throwExWithCondition(ch == EOI,
                     "[IpEx]", "parse ip failed,check the ip express:" + sb.toString());
             sb.append(ch);
         } while ((ch = nextChar()) != quotation);
@@ -350,9 +350,11 @@ public class RoutesLexer {
 
 
     /**
-     * @param expects
-     * @param isThrow
-     * @return
+     * require next char or throw ex
+     *
+     * @param expects expects char []
+     * @param isThrow if or not throw ex
+     * @return {@code true } or {@code false}
      */
     private boolean require(char[] expects, boolean isThrow) {
         char actual = nextChar();
@@ -362,8 +364,8 @@ public class RoutesLexer {
             }
         }
         throwExWithCondition(isThrow,
-                "[RequireEx]", "require char: " + expects.toString() + " but actual char: " + actual);
-        logger.debug("require char: " + expects.toString() + " but actual char: " + actual);
+                "[RequireEx]", "require char: " + Arrays.toString(expects) + " but actual char: " + actual);
+        logger.debug("require char: " + Arrays.toString(expects) + " but actual char: " + actual);
         return false;
     }
 }

--- a/dapeng-router/src/main/java/com/github/dapeng/router/RoutesLexer.java
+++ b/dapeng-router/src/main/java/com/github/dapeng/router/RoutesLexer.java
@@ -38,14 +38,17 @@ public class RoutesLexer {
     static SimpleToken Token_SEMI_COLON = new SimpleToken(Token.SEMI_COLON);
     static SimpleToken Token_COMMA = new SimpleToken(Token.COMMA);
 
+
+
     /**
      * IP_REGEX
-     * todo: 暂时只支持全格式IP(加掩码), 对于192.168.10/24这种不支持
+     * 暂时只支持全格式IP(加掩码), 对于192.168.10/24这种不支持
      */
     private static final String IP_REGEX = "(^(1\\d{2}|2[0-4]\\d|25[0-5]|[1-9]\\d|[1-9])\\.(1\\d{2}|2[0-4]\\d|25[0-5]|[1-9]\\d|\\d)\\."
-            + "(1\\d{2}|2[0-4]\\d|25[0-5]|[1-9]\\d|\\d)\\.(1\\d{2}|2[0-4]\\d|25[0-5]|[1-9]\\d|\\d))(/(\\d{2}))?$";
+            + "(1\\d{2}|2[0-4]\\d|25[0-5]|[1-9]\\d|\\d)\\.(1\\d{2}|2[0-4]\\d|25[0-5]|[1-9]\\d|\\d))(/(\\d{2}))?(:(\\d{2,5}))?$";
+
     private static final Pattern IP_PATTERN = Pattern.compile(IP_REGEX);
-    private static final int DEFAULT_MASK = 32;
+
 
     /**
      * 求模正则, 例如 1024n+0-8
@@ -302,14 +305,15 @@ public class RoutesLexer {
             String ipStr = matcher.group(1);
             int ip = IPUtils.transferIp(ipStr);
 
-            String masks = matcher.group(7);
-            if (masks != null) {
-                int mask = Integer.parseInt(masks);
-                return new IpToken(ip, mask);
-            } else {
-                // 默认值，mask
-                return new IpToken(ip, DEFAULT_MASK);
-            }
+            // parse ip mask
+            String maskStr = matcher.group(7);
+            int mask = maskStr != null ? Integer.parseInt(maskStr) : IpToken.DEFAULT_MASK;
+
+            // parse ip port
+            String portStr = matcher.group(9);
+            int port = portStr != null ? Integer.parseInt(portStr) : IpToken.DEFAULT_PORT;
+
+            return new IpToken(ip, port, mask);
         }
         throw new ParsingException("[IpEx]", "parse ip failed,check the ip express");
     }

--- a/dapeng-router/src/main/java/com/github/dapeng/router/RoutesParser.java
+++ b/dapeng-router/src/main/java/com/github/dapeng/router/RoutesParser.java
@@ -124,10 +124,10 @@ public class RoutesParser {
                 return new Otherwise();
             case Token.ID:
                 Matcher matcher = matcher();
-                matchers.macthers.add(matcher);
+                matchers.matchers.add(matcher);
                 while (lexer.peek() == Token_SEMI_COLON) {
                     lexer.next(Token.SEMI_COLON);
-                    matchers.macthers.add(matcher());
+                    matchers.matchers.add(matcher());
                 }
                 return matchers;
             default:
@@ -276,11 +276,11 @@ public class RoutesParser {
             case Token.NOT: {
                 lexer.next(Token.NOT);
                 ThenIp it = rightPattern();
-                return new ThenIp(!it.not, it.ip, it.mask);
+                return new ThenIp(!it.not, it.ip, it.port, it.mask);
             }
             case Token.IP: {
                 IpToken ip = (IpToken) lexer.next(Token.IP);
-                return new ThenIp(false, ip.ip, ip.mask);
+                return new ThenIp(false, ip.ip, ip.port, ip.mask);
             }
             default:
                 error("expect '~ip' or 'ip' but got:" + token);

--- a/dapeng-router/src/main/java/com/github/dapeng/router/RoutesParser.java
+++ b/dapeng-router/src/main/java/com/github/dapeng/router/RoutesParser.java
@@ -105,15 +105,11 @@ public class RoutesParser {
      * left  : 'otherwise' matcher (';' matcher)*
      * <p>
      * method match pattern1,pattern2
-     */
-
-    /**
+     * <p>
      * method match s'getFoo',s'setFoo' ; version match s'1.0.0',s'1.0.1' => right
      * 分号 分隔 之间 是一个 Matcher
      * <p>
      * 一个 Matcher 有多个 pattern
-     *
-     * @return
      */
     public Condition left() {
         Matchers matchers = new Matchers();
@@ -136,14 +132,10 @@ public class RoutesParser {
         }
     }
 
-    /*
-     matcher : id 'match' patterns
-     */
-
     /**
+     * matcher : id 'match' patterns
+     * <p>
      * method match "getFoo","setFoo"
-     *
-     * @return
      */
     public Matcher matcher() {
 
@@ -173,8 +165,6 @@ public class RoutesParser {
      * method match s'getFoo',s'setFoo';version match s'1.0.0',s'1.0.1' => right    (1)
      * <p>
      * method match s'getFoo',s'setFoo' => right                (2)
-     *
-     * @return
      */
     public List<Pattern> patterns() {
         List<Pattern> patterns = new ArrayList<>();
@@ -196,8 +186,6 @@ public class RoutesParser {
      * s'setFoo'
      * <p>
      * s'getFoo*'
-     *
-     * @return
      */
     public Pattern pattern() {
         // s'getFoo'
@@ -267,8 +255,6 @@ public class RoutesParser {
 
     /**
      * ？
-     *
-     * @return
      */
     public ThenIp rightPattern() {
         Token token = lexer.peek();

--- a/dapeng-router/src/main/java/com/github/dapeng/router/ThenIp.java
+++ b/dapeng-router/src/main/java/com/github/dapeng/router/ThenIp.java
@@ -16,20 +16,19 @@ import com.github.dapeng.core.helper.IPUtils;
 public class ThenIp {
     public final boolean not;
     public final int ip;
+    public final int port;
     public final int mask;
 
-    ThenIp(boolean not, int ip, int mask) {
+
+    public ThenIp(boolean not, int ip, int port, int mask) {
         this.not = not;
         this.ip = ip;
+        this.port = port;
         this.mask = mask;
     }
 
     @Override
     public String toString() {
-        return "ThenIp{" +
-                "not=" + not +
-                ", ip=" + IPUtils.transferIp(ip) +
-                ", mask=" + mask +
-                '}';
+        return "ThenIp{" + "not=" + not + ", ip=" + IPUtils.transferIp(ip) + "/" + mask + ", port=" + port + '}';
     }
 }

--- a/dapeng-router/src/main/java/com/github/dapeng/router/condition/Matcher.java
+++ b/dapeng-router/src/main/java/com/github/dapeng/router/condition/Matcher.java
@@ -33,9 +33,6 @@ public class Matcher {
 
     @Override
     public String toString() {
-        return "Matcher{" +
-                "id='" + id + '\'' +
-                ", patterns=" + patterns +
-                '}';
+        return "Matcher{" + "id='" + id + '\'' + ", patterns=" + patterns + '}';
     }
 }

--- a/dapeng-router/src/main/java/com/github/dapeng/router/condition/Matchers.java
+++ b/dapeng-router/src/main/java/com/github/dapeng/router/condition/Matchers.java
@@ -10,12 +10,10 @@ import java.util.List;
  * @date 2018年04月13日 下午9:38
  */
 public class Matchers implements Condition {
-    public List<Matcher> macthers = new ArrayList<>();
+    public List<Matcher> matchers = new ArrayList<>();
 
     @Override
     public String toString() {
-        return "Matchers{" +
-                "macthers=" + macthers +
-                '}';
+        return "Matchers{" + "matchers=" + matchers + '}';
     }
 }

--- a/dapeng-router/src/main/java/com/github/dapeng/router/token/IpToken.java
+++ b/dapeng-router/src/main/java/com/github/dapeng/router/token/IpToken.java
@@ -9,18 +9,33 @@ import com.github.dapeng.core.helper.IPUtils;
  * @date 2018年04月13日 下午9:08
  */
 public class IpToken extends SimpleToken {
-
+    /**
+     * remote server ip,Representative form by int
+     */
     public final int ip;
+    /**
+     * remote server port default 0
+     */
+    public final int port;
+    /**
+     * remote ip mask
+     */
     public final int mask;
 
-    public IpToken(int ip, int mask) {
+    public static final int DEFAULT_MASK = 32;
+    public static final int DEFAULT_PORT = 0;
+
+
+    public IpToken(int ip, int port, int mask) {
         super(IP);
         this.ip = ip;
+        this.port = port;
         this.mask = mask;
     }
 
+
     @Override
     public String toString() {
-        return "IpToken[type:" + type + ", ip:" + IPUtils.transferIp(ip) + "/" + mask + "]";
+        return "IpToken[type:" + type + ", ip:" + IPUtils.transferIp(ip) + "/" + mask + ", port:" + port + " ]";
     }
 }

--- a/dapeng-router/src/test/java/RouterIpAndPortTest.java
+++ b/dapeng-router/src/test/java/RouterIpAndPortTest.java
@@ -1,0 +1,251 @@
+import com.github.dapeng.core.InvocationContextImpl;
+import com.github.dapeng.core.RuntimeInstance;
+import com.github.dapeng.router.Route;
+import com.github.dapeng.router.RoutesExecutor;
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 路由 ip port 单元测试
+ */
+public class RouterIpAndPortTest {
+    private RuntimeInstance runtimeInstance1_9090 = new RuntimeInstance("com.maple.Uservice", "192.168.1.101", 9090, "1.0.0");
+    private RuntimeInstance runtimeInstance1_9091 = new RuntimeInstance("com.maple.Uservice", "192.168.1.101", 9091, "1.0.0");
+    private RuntimeInstance runtimeInstance2_____ = new RuntimeInstance("com.maple.Uservice", "192.168.1.102", 9092, "1.0.0");
+    private RuntimeInstance runtimeInstance3_9087 = new RuntimeInstance("com.maple.Uservice", "192.168.1.103", 9087, "1.0.0");
+    private RuntimeInstance runtimeInstance3_9091 = new RuntimeInstance("com.maple.Uservice", "192.168.1.103", 9091, "1.0.0");
+
+    private List<RuntimeInstance> prepare(InvocationContextImpl ctx, List<Route> routes) {
+        List<RuntimeInstance> instances = new ArrayList<>();
+        instances.add(runtimeInstance1_9090);
+        instances.add(runtimeInstance1_9091);
+        instances.add(runtimeInstance2_____);
+        instances.add(runtimeInstance3_9087);
+        instances.add(runtimeInstance3_9091);
+        return RoutesExecutor.executeRoutes(ctx, routes, instances);
+    }
+
+
+    /**
+     * 1.more useful
+     */
+    @Test
+    public void testMore() {
+        String pattern = "  otherwise  => ip\"192.168.1.101:9090\" , ip\"192.168.1.102\"";
+        List<Route> routes = RoutesExecutor.parseAll(pattern);
+        InvocationContextImpl ctx = (InvocationContextImpl) InvocationContextImpl.Factory.currentInstance();
+        List<RuntimeInstance> prepare = prepare(ctx, routes);
+
+        List<RuntimeInstance> expectInstances = new ArrayList<>();
+        expectInstances.add(runtimeInstance1_9090);
+        expectInstances.add(runtimeInstance2_____);
+        Assert.assertArrayEquals(expectInstances.toArray(), prepare.toArray());
+    }
+
+    /**
+     * 1.more useful
+     */
+    @Test
+    public void testMore2() {
+        String pattern = "  otherwise  => ip\"192.168.1.101:9090\" , ip\"192.168.1.103\"";
+        List<Route> routes = RoutesExecutor.parseAll(pattern);
+        InvocationContextImpl ctx = (InvocationContextImpl) InvocationContextImpl.Factory.currentInstance();
+        List<RuntimeInstance> prepare = prepare(ctx, routes);
+
+        List<RuntimeInstance> expectInstances = new ArrayList<>();
+        expectInstances.add(runtimeInstance1_9090);
+        expectInstances.add(runtimeInstance3_9087);
+        expectInstances.add(runtimeInstance3_9091);
+
+        Assert.assertArrayEquals(expectInstances.toArray(), prepare.toArray());
+    }
+
+    /**
+     * 2.精确指定到一个节点的一个端口
+     */
+    @Test
+    public void testIpPortOne() {
+        String pattern = "  otherwise  => ip\"192.168.1.101:9090\"";
+        List<Route> routes = RoutesExecutor.parseAll(pattern);
+        InvocationContextImpl ctx = (InvocationContextImpl) InvocationContextImpl.Factory.currentInstance();
+        List<RuntimeInstance> prepare = prepare(ctx, routes);
+
+        List<RuntimeInstance> expectInstances = new ArrayList<>();
+        expectInstances.add(runtimeInstance1_9090);
+        Assert.assertArrayEquals(expectInstances.toArray(), prepare.toArray());
+    }
+
+    /**
+     * 1.不指定节点，根据IP来
+     */
+    @Test
+    public void testIpNoPort() {
+        String pattern = "  otherwise  => ip\"192.168.1.101\"";
+        List<Route> routes = RoutesExecutor.parseAll(pattern);
+        InvocationContextImpl ctx = (InvocationContextImpl) InvocationContextImpl.Factory.currentInstance();
+        List<RuntimeInstance> prepare = prepare(ctx, routes);
+
+        List<RuntimeInstance> expectInstances = new ArrayList<>();
+        expectInstances.add(runtimeInstance1_9090);
+        expectInstances.add(runtimeInstance1_9091);
+        Assert.assertArrayEquals(expectInstances.toArray(), prepare.toArray());
+    }
+
+    /**
+     * 1.指定端口，根据 not 规则
+     */
+    @Test
+    public void testIpANdPortAndNot() {
+        String pattern = "  otherwise  => ~ip\"192.168.1.101:9090\"";
+        List<Route> routes = RoutesExecutor.parseAll(pattern);
+        InvocationContextImpl ctx = (InvocationContextImpl) InvocationContextImpl.Factory.currentInstance();
+        List<RuntimeInstance> prepare = prepare(ctx, routes);
+
+        List<RuntimeInstance> expectInstances = new ArrayList<>();
+        expectInstances.add(runtimeInstance1_9091);
+        expectInstances.add(runtimeInstance2_____);
+        expectInstances.add(runtimeInstance3_9087);
+        expectInstances.add(runtimeInstance3_9091);
+        Assert.assertArrayEquals(expectInstances.toArray(), prepare.toArray());
+    }
+
+    /**
+     * 1.指定端口，根据 not 规则
+     */
+    @Test
+    public void testIpNoPortAndNot() {
+        String pattern = "  otherwise  => ~ip\"192.168.1.101\"";
+        List<Route> routes = RoutesExecutor.parseAll(pattern);
+        InvocationContextImpl ctx = (InvocationContextImpl) InvocationContextImpl.Factory.currentInstance();
+        List<RuntimeInstance> prepare = prepare(ctx, routes);
+
+        List<RuntimeInstance> expectInstances = new ArrayList<>();
+        expectInstances.add(runtimeInstance2_____);
+        expectInstances.add(runtimeInstance3_9087);
+        expectInstances.add(runtimeInstance3_9091);
+        Assert.assertArrayEquals(expectInstances.toArray(), prepare.toArray());
+    }
+
+    /**
+     * 1.指定 ip 端口，根据 mask 进行匹配
+     */
+    @Test
+    public void testIpAndPortAndMask() {
+        String pattern = "  otherwise  => ip\"192.168.1.101/24:9091\"";
+        List<Route> routes = RoutesExecutor.parseAll(pattern);
+        InvocationContextImpl ctx = (InvocationContextImpl) InvocationContextImpl.Factory.currentInstance();
+        List<RuntimeInstance> prepare = prepare(ctx, routes);
+
+        List<RuntimeInstance> expectInstances = new ArrayList<>();
+        expectInstances.add(runtimeInstance1_9091);
+        expectInstances.add(runtimeInstance3_9091);
+        Assert.assertArrayEquals(expectInstances.toArray(), prepare.toArray());
+    }
+
+    /**
+     * 1.指定 ip 端口，根据 mask 进行匹配 \ not规则
+     */
+    @Test
+    public void testIpAndPortAndMaskAndNot() {
+        String pattern = "  otherwise  => ~ip\"192.168.1.101/24:9091\"";
+        List<Route> routes = RoutesExecutor.parseAll(pattern);
+        InvocationContextImpl ctx = (InvocationContextImpl) InvocationContextImpl.Factory.currentInstance();
+        List<RuntimeInstance> prepare = prepare(ctx, routes);
+
+        List<RuntimeInstance> expectInstances = new ArrayList<>();
+        expectInstances.add(runtimeInstance1_9090);
+        expectInstances.add(runtimeInstance2_____);
+        expectInstances.add(runtimeInstance3_9087);
+        Assert.assertArrayEquals(expectInstances.toArray(), prepare.toArray());
+    }
+
+    /**
+     * 多 ip 指定
+     */
+    @Test
+    public void testIpAndPortMoreIp() {
+        String pattern = "  otherwise  => ip\"192.168.1.101:9091\" , ip\"192.168.1.102\"";
+        List<Route> routes = RoutesExecutor.parseAll(pattern);
+        InvocationContextImpl ctx = (InvocationContextImpl) InvocationContextImpl.Factory.currentInstance();
+        List<RuntimeInstance> prepare = prepare(ctx, routes);
+
+        List<RuntimeInstance> expectInstances = new ArrayList<>();
+        expectInstances.add(runtimeInstance1_9091);
+        expectInstances.add(runtimeInstance2_____);
+        Assert.assertArrayEquals(expectInstances.toArray(), prepare.toArray());
+    }
+
+    /**
+     * 多 ip 指定
+     */
+    @Test
+    public void testIpAndPortMoreIpMask() {
+        String pattern = "  otherwise  => ip\"192.168.1.101/24:9091\" , ip\"192.168.1.102\"";
+        List<Route> routes = RoutesExecutor.parseAll(pattern);
+        InvocationContextImpl ctx = (InvocationContextImpl) InvocationContextImpl.Factory.currentInstance();
+        List<RuntimeInstance> prepare = prepare(ctx, routes);
+
+        List<RuntimeInstance> expectInstances = new ArrayList<>();
+        expectInstances.add(runtimeInstance1_9091);
+        expectInstances.add(runtimeInstance2_____);
+        expectInstances.add(runtimeInstance3_9091);
+        Assert.assertArrayEquals(expectInstances.toArray(), prepare.toArray());
+    }
+
+    /**
+     * 多 ip 指定
+     */
+    @Test
+    public void testIpAndPortMoreIpMask2() {
+        String pattern = "  otherwise  => ip\"192.168.1.101/24\" , ~ip\"192.168.1.102\"";
+        List<Route> routes = RoutesExecutor.parseAll(pattern);
+        InvocationContextImpl ctx = (InvocationContextImpl) InvocationContextImpl.Factory.currentInstance();
+        List<RuntimeInstance> prepare = prepare(ctx, routes);
+
+        List<RuntimeInstance> expectInstances = new ArrayList<>();
+        expectInstances.add(runtimeInstance1_9090);
+        expectInstances.add(runtimeInstance1_9091);
+        expectInstances.add(runtimeInstance3_9087);
+        expectInstances.add(runtimeInstance3_9091);
+        Assert.assertArrayEquals(expectInstances.toArray(), prepare.toArray());
+    }
+
+    /**
+     * not mode
+     */
+    @Test
+    public void testIpAndPortNot() {
+        String pattern = "  otherwise  => ~ip\"192.168.1.101\" , ~ip\"192.168.1.102\"";
+        List<Route> routes = RoutesExecutor.parseAll(pattern);
+        InvocationContextImpl ctx = (InvocationContextImpl) InvocationContextImpl.Factory.currentInstance();
+        List<RuntimeInstance> prepare = prepare(ctx, routes);
+
+        List<RuntimeInstance> expectInstances = new ArrayList<>();
+        expectInstances.add(runtimeInstance3_9087);
+        expectInstances.add(runtimeInstance3_9091);
+        Assert.assertArrayEquals(expectInstances.toArray(), prepare.toArray());
+    }
+
+    /**
+     * not mode
+     */
+    @Test
+    public void testIpAndPortNotAndMore() {
+        String pattern = "  otherwise  => ~ip\"192.168.1.101:9090\" , ip\"192.168.1.101/24\"";
+        List<Route> routes = RoutesExecutor.parseAll(pattern);
+        InvocationContextImpl ctx = (InvocationContextImpl) InvocationContextImpl.Factory.currentInstance();
+        List<RuntimeInstance> prepare = prepare(ctx, routes);
+
+        List<RuntimeInstance> expectInstances = new ArrayList<>();
+        expectInstances.add(runtimeInstance1_9091);
+        expectInstances.add(runtimeInstance2_____);
+        expectInstances.add(runtimeInstance3_9087);
+        expectInstances.add(runtimeInstance3_9091);
+        Assert.assertArrayEquals(expectInstances.toArray(), prepare.toArray());
+    }
+
+
+}

--- a/dapeng-router/src/test/java/TestRegex.java
+++ b/dapeng-router/src/test/java/TestRegex.java
@@ -1,0 +1,52 @@
+import com.github.dapeng.core.helper.IPUtils;
+import com.github.dapeng.router.token.IpToken;
+import org.junit.Test;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+
+public class TestRegex {
+    private static final String IP_REGEX = "(^(1\\d{2}|2[0-4]\\d|25[0-5]|[1-9]\\d|[1-9])\\.(1\\d{2}|2[0-4]\\d|25[0-5]|[1-9]\\d|\\d)\\."
+            + "(1\\d{2}|2[0-4]\\d|25[0-5]|[1-9]\\d|\\d)\\.(1\\d{2}|2[0-4]\\d|25[0-5]|[1-9]\\d|\\d))(/(\\d{2}))?(:(\\d{2,5}))?$";
+
+    private Pattern IP_PATTERN = Pattern.compile(IP_REGEX);
+
+    private static final Pattern SIMPLE = Pattern.compile("\\d{2,4}");
+
+    @Test
+    public void testOne() {
+        String str = "133";
+        Matcher matcher = SIMPLE.matcher(str);
+
+        System.out.println(matcher.matches());
+
+    }
+
+    @Test
+    public void testTwo() {
+        String str = "192.168.20.103";
+        Matcher matcher = IP_PATTERN.matcher(str);
+
+        if (matcher.matches()) {
+            String ipStr = matcher.group(1);
+            int ip = IPUtils.transferIp(ipStr);
+            System.out.println(ip);
+
+            String masks = matcher.group(7);
+            if (masks != null) {
+                int mask = Integer.parseInt(masks);
+                System.out.println(mask);
+
+            }
+
+            String port = matcher.group(8);
+            if (port != null) {
+                System.out.println(port);
+            }
+        }else {
+            System.err.println("not matcher");
+        }
+
+    }
+}

--- a/dapeng-router/src/test/java/TestRouterRuntimeList.java
+++ b/dapeng-router/src/test/java/TestRouterRuntimeList.java
@@ -616,5 +616,20 @@ public class TestRouterRuntimeList {
 
     }
 
+    @Test
+    public void testRegexCookieTest() {
+        String pattern = "  cookie_storeId  match r'100.*'  => ip\"192.168.1.101\"";
+
+        List<Route> routes = RoutesExecutor.parseAll(pattern);
+        InvocationContextImpl ctx = (InvocationContextImpl) InvocationContextImpl.Factory.currentInstance();
+        ctx.setCookie("storeId", "100201");
+        List<RuntimeInstance> prepare = prepare(ctx, routes);
+
+        List<RuntimeInstance> expectInstances = new ArrayList<>();
+        expectInstances.add(runtimeInstance1);
+
+        Assert.assertArrayEquals(expectInstances.toArray(), prepare.toArray());
+    }
+
 
 }


### PR DESCRIPTION
路由规则增加支持端口。可以精确指定端口进行路由，适合同一服务部署在一个节点上，可以根据其端口来精确路由。也可以不配置端口，不配置默认为0，将不会通过端口来进行路由。