### PR TITLE
enhance dapeng-container for more startup modes

### DIFF
--- a/dapeng-api-doc/pom.xml
+++ b/dapeng-api-doc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>dapeng-parent</artifactId>
         <groupId>com.github.dapeng-soa</groupId>
-        <version>2.2.0</version>
+        <version>2.2.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/dapeng-client-netty/pom.xml
+++ b/dapeng-client-netty/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>dapeng-parent</artifactId>
         <groupId>com.github.dapeng-soa</groupId>
-        <version>2.2.0</version>
+        <version>2.2.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/dapeng-code-generator/pom.xml
+++ b/dapeng-code-generator/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>dapeng-parent</artifactId>
         <groupId>com.github.dapeng-soa</groupId>
-        <version>2.2.0</version>
+        <version>2.2.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/dapeng-container/dapeng-bootstrap/pom.xml
+++ b/dapeng-container/dapeng-bootstrap/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>dapeng-container</artifactId>
         <groupId>com.github.dapeng-soa</groupId>
-        <version>2.2.0</version>
+        <version>2.2.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/dapeng-container/dapeng-bootstrap/src/main/java/com/github/dapeng/bootstrap/Bootstrap.java
+++ b/dapeng-container/dapeng-bootstrap/src/main/java/com/github/dapeng/bootstrap/Bootstrap.java
@@ -33,9 +33,9 @@ import java.util.stream.Collectors;
 public class Bootstrap {
     private static final String ENGINE_PATH = initialzie();
 
-    private static String initialzie(){
+    private static String initialzie() {
         String soaBase = getEnginePath();
-        if(System.getProperty("soa.container.logging.path")==null){
+        if (System.getProperty("soa.container.logging.path") == null) {
             System.setProperty("soa.container.logging.path", soaBase + "/logs/");
         }
         return soaBase;
@@ -44,22 +44,20 @@ public class Bootstrap {
     private static String getEnginePath() {
 
         String base = System.getProperty("soa.base");
-        if(base != null) return base;
+        if (base != null) return base;
 
         File classPath = new File(Bootstrap.class.getProtectionDomain().getCodeSource().getLocation().getFile());
-        if(classPath.isDirectory()){
+        if (classPath.isDirectory()) {
             // in DEV mode, root/dapeng-container/dapeng-bootstrap/target/classes
             base = classPath.getParentFile()    // root/dapeng-container/dapeng-bootstrap/target
                     .getParentFile()    // root/dapeng-container/dapeng-bootstrap/
                     .getParentFile()    // root/dapeng-container/
                     .getPath() + "/dapeng-container-impl/target/dapeng-container";
-        }
-        else if(classPath.getName().endsWith(".jar")) { // HOME/bin/dapeng-bootstrap.jar
+        } else if (classPath.getName().endsWith(".jar")) { // HOME/bin/dapeng-bootstrap.jar
             base = classPath.getParentFile() // HOME/bin
                     .getParentFile() // HOME
                     .getPath();
-        }
-        else {
+        } else {
             throw new RuntimeException("please specify engine's home via -Dsoa.base");
         }
         System.setProperty("soa.base", base);
@@ -74,35 +72,32 @@ public class Bootstrap {
         String appsDir = null;
         List<String> appFiles = new ArrayList<>();
 
-        for(int i=0; i<args.length; i++){
-            if("-apps".equals(args[i]) && (i+1)<args.length){
-                if(appsDir != null) {
+        for (int i = 0; i < args.length; i++) {
+            if ("-apps".equals(args[i]) && (i + 1) < args.length) {
+                if (appsDir != null) {
                     throw new RuntimeException("too many -apps options");
-                }
-                else {
+                } else {
                     appsDir = args[i + 1];
                     i++;
                     continue;
                 }
-            }
-            else if("-app".equals(args[i]) && (i+1)<args.length){
-                appFiles.add(args[i+1]);
+            } else if ("-app".equals(args[i]) && (i + 1) < args.length) {
+                appFiles.add(args[i + 1]);
                 i++;
                 continue;
-            }
-            else if("-logdir".equals(args[i]) && (i+1)<args.length){
-                System.setProperty("soa.container.logging.path", args[i+1]);
+            } else if ("-logdir".equals(args[i]) && (i + 1) < args.length) {
+                System.setProperty("soa.container.logging.path", args[i + 1]);
                 i++;
                 continue;
             }
         }
 
-        if(appsDir != null){
+        if (appsDir != null) {
             File dir = new File(appsDir);
-            if(!dir.isDirectory()) throw new RuntimeException("apps " + appsDir + " is not a directory");
-            for(File app: dir.listFiles()) {
-                if(app.isDirectory()) appFiles.add(app.getPath());
-                else if(app.isFile() && app.getPath().endsWith(".jar")) appFiles.add(app.getPath());
+            if (!dir.isDirectory()) throw new RuntimeException("apps " + appsDir + " is not a directory");
+            for (File app : dir.listFiles()) {
+                if (app.isDirectory()) appFiles.add(app.getPath());
+                else if (app.isFile() && app.getPath().endsWith(".jar")) appFiles.add(app.getPath());
             }
         }
 
@@ -176,25 +171,23 @@ public class Bootstrap {
     }
 
     /**
-     *
      * @param apps each app is ethier a single jar or a directory
      * @return
      * @throws MalformedURLException
      */
     private static List<List<URL>> findAppJars(List<String> apps) throws MalformedURLException {
         List<List<URL>> result = new ArrayList<>();
-        for(String app: apps){
+        for (String app : apps) {
             File appFile = new File(app);
-            if(appFile.isFile() && appFile.getPath().endsWith(".jar")) {
+            if (appFile.isFile() && appFile.getPath().endsWith(".jar")) {
                 List<URL> jars = new ArrayList<>();
                 jars.add(appFile.toURI().toURL());
                 result.add(jars);
                 continue;
-            }
-            else if(appFile.isDirectory()){
+            } else if (appFile.isDirectory()) {
                 List<URL> jars = new ArrayList<>();
                 jars.addAll(findJarURLs(appFile));
-                if(!jars.isEmpty())
+                if (!jars.isEmpty())
                     result.add(jars);
             }
         }

--- a/dapeng-container/dapeng-container-api/pom.xml
+++ b/dapeng-container/dapeng-container-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>dapeng-container</artifactId>
         <groupId>com.github.dapeng-soa</groupId>
-        <version>2.2.0</version>
+        <version>2.2.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/dapeng-container/dapeng-container-impl/pom.xml
+++ b/dapeng-container/dapeng-container-impl/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>dapeng-container</artifactId>
         <groupId>com.github.dapeng-soa</groupId>
-        <version>2.2.0</version>
+        <version>2.2.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -13,7 +13,7 @@
 
     <properties>
         <devName>dapeng-container</devName>
-        <dapeng-version>2.2.0</dapeng-version>
+        <dapeng-version>2.2.1</dapeng-version>
     </properties>
 
     <build>
@@ -46,6 +46,7 @@
                         <directory>${basedir}/src/main/command</directory>
                         <includes>
                             <include>startup.sh</include>
+                            <include>startup_dapeng.sh</include>
                             <include>shutdown.sh</include>
                         </includes>
                         <targetPath>${project.build.directory}/${devName}/bin</targetPath>
@@ -81,7 +82,7 @@
                                     <overWriteSnapshots>false</overWriteSnapshots>
                                     <overWriteIfNewer>true</overWriteIfNewer>
                                     <includeArtifactIds>
-                                        dapeng-core
+                                        dapeng-core,dapeng-transaction-api
                                     </includeArtifactIds>
                                 </configuration>
                             </execution>
@@ -98,7 +99,7 @@
                                     <overWriteSnapshots>false</overWriteSnapshots>
                                     <overWriteIfNewer>true</overWriteIfNewer>
                                     <excludeArtifactIds>
-                                        dapeng-core,commons-logging,dapeng-message-api,dapeng-api-doc,dapeng-message-kafka,kafka_2.12,kafka-clients,jopt-simple,metrics-core
+                                        dapeng-core,dapeng-transaction-api,commons-logging,dapeng-message-api,dapeng-api-doc,dapeng-message-kafka,kafka_2.12,kafka-clients,jopt-simple,metrics-core
                                     </excludeArtifactIds>
                                 </configuration>
                             </execution>
@@ -298,7 +299,7 @@
         <dependency>
             <groupId>org.quartz-scheduler</groupId>
             <artifactId>quartz</artifactId>
-            <version>2.2.0</version>
+            <version>2.2.1</version>
         </dependency>
     </dependencies>
 </project>

--- a/dapeng-container/dapeng-container-impl/src/main/command/startup_dapeng.sh
+++ b/dapeng-container/dapeng-container-impl/src/main/command/startup_dapeng.sh
@@ -100,17 +100,5 @@ for fluentPid in $(pgrep -f fluent-bit)
 }
 
 
-trap 'kill ${!};process_exit' SIGTERM
-
-echo $JAVA_OPTS > $LOGDIR/console.log
-
-nohup java -server $JAVA_OPTS -cp $PRGDIR/dapeng-bootstrap.jar com.github.dapeng.bootstrap.Bootstrap $* >> $LOGDIR/console.log 2>&1 &
-pid="$!"
-echo $pid > $LOGDIR/pid.txt
-
-if [ "$fluent_bit_enable" == "true" ]; then
-   nohup sh /opt/fluent-bit/fluent-bit.sh >> $LOGDIR/fluent-bit.log 2>&1 &
-fi
-
-wait $pid
+java -server $JAVA_OPTS -cp $PRGDIR/dapeng-bootstrap.jar com.github.dapeng.bootstrap.Bootstrap $*
 

--- a/dapeng-container/dapeng-container-impl/src/main/java/com/github/dapeng/impl/container/DapengContainer.java
+++ b/dapeng-container/dapeng-container-impl/src/main/java/com/github/dapeng/impl/container/DapengContainer.java
@@ -55,7 +55,7 @@ import static com.github.dapeng.core.helper.SoaSystemEnvProperties.SOA_SHUTDOWN_
 public class DapengContainer implements Container {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DapengContainer.class);
-    private static final String RUN_MODE = System.getProperty("soa.run.mode", "plugin");
+    private static final String RUN_MODE = System.getProperty("soa.run.mode", "native");
     private List<AppListener> appListeners = new Vector<>();
     private List<Application> applications = new Vector<>();
     private List<Plugin> plugins = new ArrayList<>();

--- a/dapeng-container/dapeng-container-impl/src/main/java/com/github/dapeng/impl/filters/freq/ShmManager.java
+++ b/dapeng-container/dapeng-container-impl/src/main/java/com/github/dapeng/impl/filters/freq/ShmManager.java
@@ -137,7 +137,14 @@ public class ShmManager {
             LOGGER.warn("ShmManager::init, MMAP file not exist, now create one");
             String parentPath = SoaSystemEnvProperties.SOA_FREQ_SHM_DATA.substring(0,SoaSystemEnvProperties.SOA_FREQ_SHM_DATA.lastIndexOf('/'));
             new File(parentPath).mkdirs();
-            boolean succeed = file.createNewFile();
+            boolean succeed = false;
+            try {
+                succeed = file.createNewFile();
+            }
+            catch(IOException ex){
+                LOGGER.error("Can't open shm file:" + file + ", You may run with -Dsoa.freq.limit.enable=false or -Dsoa.freq.shm.data=filename to avoid this error", ex);
+                throw ex;
+            }
             LOGGER.warn("ShmManager::init, MMAP file created:" + (succeed?"succeed":"failed"));
         }
         RandomAccessFile access = new RandomAccessFile(file, "rw");

--- a/dapeng-container/dapeng-container-impl/src/main/resources/logback.xml
+++ b/dapeng-container/dapeng-container-impl/src/main/resources/logback.xml
@@ -20,7 +20,7 @@
     <appender name="SIMPLEFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <prudent>false</prudent>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>${soa.base}/logs/simple-dapeng-container.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <fileNamePattern>${soa.container.logging.path}/simple-dapeng-container.%d{yyyy-MM-dd}.log</fileNamePattern>
             <maxHistory>30</maxHistory>
         </rollingPolicy>
         <encoder>
@@ -31,7 +31,7 @@
     <appender name="SLOWTIMEFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <prudent>false</prudent>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>${soa.base}/logs/slow-service.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <fileNamePattern>${soa.container.logging.path}/slow-service.%d{yyyy-MM-dd}.log</fileNamePattern>
             <maxHistory>30</maxHistory>
         </rollingPolicy>
         <encoder>
@@ -42,7 +42,7 @@
     <appender name="DETAILFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <prudent>false</prudent>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>${soa.base}/logs/detail-dapeng-container.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <fileNamePattern>${soa.container.logging.path}/detail-dapeng-container.%d{yyyy-MM-dd}.log</fileNamePattern>
             <maxHistory>30</maxHistory>
         </rollingPolicy>
         <encoder>
@@ -53,7 +53,7 @@
     <appender name="ERRORFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <prudent>false</prudent>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>${soa.base}/logs/error-dapeng-container.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <fileNamePattern>${soa.container.logging.path}/error-dapeng-container.%d{yyyy-MM-dd}.log</fileNamePattern>
             <maxHistory>30</maxHistory>
         </rollingPolicy>
         <encoder>
@@ -67,7 +67,7 @@
     <appender name="GBTRANSACTIONFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <prudent>false</prudent>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>${soa.base}/logs/transaction-dapeng-container.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <fileNamePattern>${soa.container.logging.path}/transaction-dapeng-container.%d{yyyy-MM-dd}.log</fileNamePattern>
             <maxHistory>30</maxHistory>
         </rollingPolicy>
         <encoder>
@@ -92,7 +92,7 @@
     <appender name="SCHEDULEDTASK" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <prudent>false</prudent>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>${soa.base}/logs/scheduled-task.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <fileNamePattern>${soa.container.logging.path}/scheduled-task.%d{yyyy-MM-dd}.log</fileNamePattern>
             <maxHistory>30</maxHistory>
         </rollingPolicy>
         <encoder>

--- a/dapeng-container/pom.xml
+++ b/dapeng-container/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>dapeng-parent</artifactId>
         <groupId>com.github.dapeng-soa</groupId>
-        <version>2.2.0</version>
+        <version>2.2.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/dapeng-core/pom.xml
+++ b/dapeng-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>dapeng-parent</artifactId>
         <groupId>com.github.dapeng-soa</groupId>
-        <version>2.2.0</version>
+        <version>2.2.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/dapeng-core/src/main/java/com/github/dapeng/core/helper/DapengUtil.java
+++ b/dapeng-core/src/main/java/com/github/dapeng/core/helper/DapengUtil.java
@@ -34,7 +34,7 @@ import static com.github.dapeng.core.helper.IPUtils.localIpAsInt;
  * @date 20180406
  */
 public class DapengUtil {
-    public final static String CONTAINER_VERSION = "2.2.0";
+    public final static String CONTAINER_VERSION = "2.2.1";
 
     private static AtomicInteger seqId = new AtomicInteger(ThreadLocalRandom.current().nextInt());
     private static int processId = getProcessId() << 16;

--- a/dapeng-core/src/main/java/com/github/dapeng/core/helper/SoaSystemEnvProperties.java
+++ b/dapeng-core/src/main/java/com/github/dapeng/core/helper/SoaSystemEnvProperties.java
@@ -30,18 +30,6 @@ public class SoaSystemEnvProperties {
     public static final String THREAD_LEVEL_KEY = "thread-log-level";
 
     /**
-     * 容器IP
-     * deprecated by KEY_HOST_IP
-     */
-    @Deprecated
-    private static final String KEY_SOA_CONTAINER_IP = "soa.container.ip";
-    /**
-     * 设置本地主机名称
-     * deprecated by KEY_HOST_IP
-     */
-    @Deprecated
-    private static final String KEY_SOA_LOCAL_HOST_NAME = "soa.local.host.name";
-    /**
      * 宿主机IP
      */
     private static final String KEY_HOST_IP = "host.ip";
@@ -168,10 +156,6 @@ public class SoaSystemEnvProperties {
 
     public static final boolean SOA_CONTAINER_USETHREADPOOL = Boolean.valueOf(get(KEY_SOA_CONTAINER_USETHREADPOOL, Boolean.TRUE.toString()));
 
-    @Deprecated
-    public static final String SOA_LOCAL_HOST_NAME = get(KEY_SOA_LOCAL_HOST_NAME);
-    @Deprecated
-    public static final String SOA_CONTAINER_IP = get(KEY_SOA_CONTAINER_IP, IPUtils.containerIp());
     public static final String HOST_IP = get(KEY_HOST_IP, IPUtils.containerIp());
     public static final int SOA_CONTAINER_PORT = Integer.valueOf(get(KEY_SOA_CONTAINER_PORT, "9090"));
     public static final int SOA_APIDOC_PORT = Integer.valueOf(get(KEY_SOA_APIDOC_PORT, "8080"));

--- a/dapeng-counter/dapeng-counter-api/pom.xml
+++ b/dapeng-counter/dapeng-counter-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>dapeng-counter</artifactId>
         <groupId>com.github.dapeng-soa</groupId>
-        <version>2.2.0</version>
+        <version>2.2.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/dapeng-counter/dapeng-counter-service/buildImage.sh
+++ b/dapeng-counter/dapeng-counter-service/buildImage.sh
@@ -2,5 +2,5 @@
 
 mvn clean package
 mv target/dapeng-counter-service docker/
-docker build -t dapengsoa/counter-service:2.2.0 docker/
+docker build -t dapengsoa/counter-service:2.2.1 docker/
 rm -rf docker/dapeng-counter-service

--- a/dapeng-counter/dapeng-counter-service/docker/Dockerfile
+++ b/dapeng-counter/dapeng-counter-service/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM dapengsoa/dapeng-container:2.2.0
+FROM dapengsoa/dapeng-container:2.2.1
 MAINTAINER dapengsoa@gmail.com
 
 ENV CONTAINER_HOME /dapeng-container

--- a/dapeng-counter/dapeng-counter-service/pom.xml
+++ b/dapeng-counter/dapeng-counter-service/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>dapeng-counter</artifactId>
         <groupId>com.github.dapeng-soa</groupId>
-        <version>2.2.0</version>
+        <version>2.2.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -15,7 +15,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java-version>1.8</java-version>
         <slf4j-version>1.7.13</slf4j-version>
-        <dapeng-version>2.2.0</dapeng-version>
+        <dapeng-version>2.2.1</dapeng-version>
         <influxdb-version>2.8</influxdb-version>
         <maven.deploy.skip>true</maven.deploy.skip>
         <maven.install.skip>true</maven.install.skip>

--- a/dapeng-counter/pom.xml
+++ b/dapeng-counter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>dapeng-parent</artifactId>
         <groupId>com.github.dapeng-soa</groupId>
-        <version>2.2.0</version>
+        <version>2.2.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/dapeng-json/pom.xml
+++ b/dapeng-json/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>dapeng-parent</artifactId>
         <groupId>com.github.dapeng-soa</groupId>
-        <version>2.2.0</version>
+        <version>2.2.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/dapeng-maven-plugin/README.md
+++ b/dapeng-maven-plugin/README.md
@@ -10,5 +10,5 @@
 #### Maven运行
 
 ```
-mvn compile com.github.dapeng:dapeng-maven-plugin:2.2.0:run
+mvn compile com.github.dapeng:dapeng-maven-plugin:2.2.1:run
 ```

--- a/dapeng-maven-plugin/pom.xml
+++ b/dapeng-maven-plugin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>dapeng-parent</artifactId>
         <groupId>com.github.dapeng-soa</groupId>
-        <version>2.2.0</version>
+        <version>2.2.1</version>
     </parent>
 
     <artifactId>dapeng-maven-plugin</artifactId>

--- a/dapeng-message/dapeng-message-api/pom.xml
+++ b/dapeng-message/dapeng-message-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>dapeng-message</artifactId>
         <groupId>com.github.dapeng-soa</groupId>
-        <version>2.2.0</version>
+        <version>2.2.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/dapeng-message/dapeng-message-kafka/pom.xml
+++ b/dapeng-message/dapeng-message-kafka/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>dapeng-message</artifactId>
         <groupId>com.github.dapeng-soa</groupId>
-        <version>2.2.0</version>
+        <version>2.2.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/dapeng-message/pom.xml
+++ b/dapeng-message/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>dapeng-parent</artifactId>
         <groupId>com.github.dapeng-soa</groupId>
-        <version>2.2.0</version>
+        <version>2.2.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/dapeng-registry/dapeng-registry-zookeeper/pom.xml
+++ b/dapeng-registry/dapeng-registry-zookeeper/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>dapeng-registry</artifactId>
         <groupId>com.github.dapeng-soa</groupId>
-        <version>2.2.0</version>
+        <version>2.2.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/dapeng-registry/pom.xml
+++ b/dapeng-registry/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>dapeng-parent</artifactId>
         <groupId>com.github.dapeng-soa</groupId>
-        <version>2.2.0</version>
+        <version>2.2.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/dapeng-router/pom.xml
+++ b/dapeng-router/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>dapeng-parent</artifactId>
         <groupId>com.github.dapeng-soa</groupId>
-        <version>2.2.0</version>
+        <version>2.2.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>dapeng-router</artifactId>

--- a/dapeng-spring/pom.xml
+++ b/dapeng-spring/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>dapeng-parent</artifactId>
         <groupId>com.github.dapeng-soa</groupId>
-        <version>2.2.0</version>
+        <version>2.2.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/dapeng-transaction/dapeng-transaction-api/pom.xml
+++ b/dapeng-transaction/dapeng-transaction-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>dapeng-transaction</artifactId>
         <groupId>com.github.dapeng-soa</groupId>
-        <version>2.2.0</version>
+        <version>2.2.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/dapeng-transaction/dapeng-transaction-impl/pom.xml
+++ b/dapeng-transaction/dapeng-transaction-impl/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>dapeng-transaction</artifactId>
         <groupId>com.github.dapeng-soa</groupId>
-        <version>2.2.0</version>
+        <version>2.2.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/dapeng-transaction/pom.xml
+++ b/dapeng-transaction/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>dapeng-parent</artifactId>
         <groupId>com.github.dapeng-soa</groupId>
-        <version>2.2.0</version>
+        <version>2.2.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/dapeng-utils/pom.xml
+++ b/dapeng-utils/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>dapeng-parent</artifactId>
         <groupId>com.github.dapeng-soa</groupId>
-        <version>2.2.0</version>
+        <version>2.2.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.github.dapeng-soa</groupId>
     <artifactId>dapeng-parent</artifactId>
     <packaging>pom</packaging>
-    <version>2.2.0</version>
+    <version>2.2.1</version>
 
     <name>dapeng</name>
     <description>一个简单、易用、多特性的SOA框架</description>

--- a/生成代码插件使用.md
+++ b/生成代码插件使用.md
@@ -1,6 +1,6 @@
 ### 生成代码插件使用
 
-1、安装dapeng项目(dapeng-soa  2.2.0)到本地仓库。或者进入dapeng项目的dapeng-code-generator 模块执行 mvn clean install ,再进入dapeng-maven-plugin模块执行 mvn clean install ，只安装这两个也行。
+1、安装dapeng项目(dapeng-soa  2.2.1)到本地仓库。或者进入dapeng项目的dapeng-code-generator 模块执行 mvn clean install ,再进入dapeng-maven-plugin模块执行 mvn clean install ，只安装这两个也行。
 
 2、在api项目的pom文件加入插件依赖，注释的内容language参数可以指定生成哪种语言的代码，目前只支持java和scala，不指定默认是两种代码都生成。（注意：不能在父级的pom文件加插件，比如crm-api要在各个子模块比如company-api加入插件）
 
@@ -9,7 +9,7 @@
 	        <plugin>
 	            <groupId>com.github.dapeng-soa</groupId>
 	            <artifactId>dapeng-maven-plugin</artifactId>
-	            <version>2.2.0</version>
+	            <version>2.2.1</version>
 	            <executions>
 	                <execution>
 	                    <phase>generate-sources</phase>
@@ -32,7 +32,7 @@
 	        <plugin>
 	            <groupId>com.github.dapeng-soa</groupId>
 	            <artifactId>dapeng-maven-plugin</artifactId>
-	            <version>2.2.0</version>
+	            <version>2.2.1</version>
 	            <executions>
 	                <execution>
 	                    <phase>generate-sources</phase>


### PR DESCRIPTION
# Enhance Dapeng-container for more launch modes

目前，dapeng-container 的启动方式比较单一：从当前安装目录的 apps/ 下扫描并装载服务。这种方式虽然比较简单，但并不是非常灵活。

增加了新的 startup_dapeng.sh 脚本：

startup_dapeng.sh -app app-directory-or-single-jar -apps directory-contains-more-app -logdir path-to-container-log-dir

- -app 可以指定一个app目录或者一个自包含的app-jar
- -apps 可以指定一个目录，其一级子目录或一级自文件 是 一个 app目录或者自包含的 app-jar
- -logdir 可以执行容器自身的日志目录。

TODO：
1. 未来 Dapeng-container 中还需要包括 dapeng-cli 等基本工具。
2. 2.2.1 Release should include a dapeng-container_2.2.1.zip for download.