### PR TITLE
fix bug for discard/complete synchronize.

### DIFF
--- a/dapeng-api-doc/pom.xml
+++ b/dapeng-api-doc/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.10.1</version>
+            <version>2.9.10.5</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/dapeng-client-netty/src/main/java/com/github/dapeng/client/netty/NettyClient.java
+++ b/dapeng-client-netty/src/main/java/com/github/dapeng/client/netty/NettyClient.java
@@ -86,7 +86,7 @@ public class NettyClient {
         }
 
         /*
-         * block1 in discard, and block in complete will be synchornized, so
+         * block1 in discard, and block2 in complete will be synchornized, so
          * 1. block1 then block2
          *    - block2's future2 will be null, so the ByteBuf will released
          * 2. block2 then block1


### PR DESCRIPTION
the original remove(seqId) and complete(seqId, msg) has bugs on synchronize.

1. Maybe the remove and complete both runs at the same time, the msg will be lossed without release op.